### PR TITLE
add env file to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ stats.json
 .DS_Store
 npm-debug.log
 .idea
+.env


### PR DESCRIPTION
This pull request adds the .env file to .gitignore, so developers can use a .env file for local testing.