### PR TITLE
Fix missing env var value

### DIFF
--- a/.env.local
+++ b/.env.local
@@ -1,3 +1,6 @@
+LANGUAGES=da,en,nl
+DEFAULT_LOCALE=nl
+
 CITY_NAME="SCORE"
 CITY_HEADER_THUMBNAIL="https://northsearegion.eu/media/5193/score-02a-colour.png"
 

--- a/internals/webpack/getEnvVariables.js
+++ b/internals/webpack/getEnvVariables.js
@@ -2,6 +2,7 @@ const dotenv = require('dotenv');
 
 const envVars = dotenv.config().parsed || {};
 
+// return variables from .env file
 module.exports = () => {
   const citySpecificEnvs = Object.entries(envVars).reduce((p, [key, value]) => {
     // eslint-disable-next-line no-param-reassign

--- a/internals/webpack/getEnvVariables.js
+++ b/internals/webpack/getEnvVariables.js
@@ -1,0 +1,18 @@
+const dotenv = require('dotenv');
+
+const envVars = dotenv.config().parsed || {};
+
+module.exports = () => {
+  const citySpecificEnvs = Object.entries(envVars).reduce((p, [key, value]) => {
+    // eslint-disable-next-line no-param-reassign
+    p[key] = JSON.stringify(value);
+    return p;
+  }, {});
+
+  const envs = {
+    NODE_ENV: JSON.stringify(process.env.NODE_ENV),
+    ...citySpecificEnvs
+  };
+
+  return envs;
+};

--- a/internals/webpack/webpack.base.babel.js
+++ b/internals/webpack/webpack.base.babel.js
@@ -5,8 +5,7 @@
 const path = require('path');
 const webpack = require('webpack');
 const ExtractTextPlugin = require('extract-text-webpack-plugin');
-const dotenv = require('dotenv');
-const envVars = dotenv.config().parsed || {};
+const getEnvVariables = require('./getEnvVariables');
 
 // Remove this line once the following warning goes away (it was meant for webpack loader authors not users):
 // 'DeprecationWarning: loaderUtils.parseQuery() received a non-string value which can be problematic,
@@ -94,7 +93,7 @@ module.exports = (options) => ({
     // inside your code for any environment checks; UglifyJS will automatically
     // drop any unreachable code.
     new webpack.DefinePlugin({
-      'process.env': getEnvVariables()
+      'process.env': getEnvVariables(),
     }),
     new webpack.NamedModulesPlugin(),
     new ExtractTextPlugin({
@@ -119,13 +118,3 @@ module.exports = (options) => ({
   target: options.target || 'web', // Make web variables accessible to webpack, e.g. window
   performance: options.performance || {},
 });
-
-const getEnvVariables = () => {
-  const citySpecificEnvs = Object.entries(envVars).reduce((p, [key, value]) => {
-    // eslint-disable-next-line no-param-reassign
-    p[key] = JSON.stringify(value);
-    return p;
-  }, {});
-  const envs = { NODE_ENV: JSON.stringify(process.env.NODE_ENV), ...citySpecificEnvs, };
-  return envs;
-};

--- a/internals/webpack/webpack.prod.babel.js
+++ b/internals/webpack/webpack.prod.babel.js
@@ -6,14 +6,12 @@ const OfflinePlugin = require('offline-plugin');
 
 module.exports = require('./webpack.base.babel')({
   // In production, we skip all hot-reloading stuff
-  entry: [
-    'babel-polyfill', path.join(process.cwd(), 'src/app.js'),
-  ],
+  entry: ['babel-polyfill', path.join(process.cwd(), 'src/app.js')],
 
   // Utilize long-term caching by adding content hashes (not compilation hashes) to compiled assets
   output: {
     filename: '[name].[chunkhash].js',
-    chunkFilename: '[name].[chunkhash].chunk.js',
+    chunkFilename: '[name].[chunkhash].chunk.js'
   },
 
   plugins: [
@@ -22,7 +20,7 @@ module.exports = require('./webpack.base.babel')({
       name: 'vendor',
       children: true,
       minChunks: 2,
-      async: true,
+      async: true
     }),
 
     // Minify and optimize the index.html
@@ -38,9 +36,9 @@ module.exports = require('./webpack.base.babel')({
         keepClosingSlash: true,
         minifyJS: true,
         minifyCSS: true,
-        minifyURLs: true,
+        minifyURLs: true
       },
-      inject: true,
+      inject: true
     }),
 
     // Put it in the end to capture all the HtmlWebpackPlugin's
@@ -59,17 +57,18 @@ module.exports = require('./webpack.base.babel')({
         // All chunks marked as `additional`, loaded after main section
         // and do not prevent SW to install. Change to `optional` if
         // do not want them to be preloaded at all (cached only when first loaded)
-        additional: ['*.chunk.js'],
+        additional: ['*.chunk.js']
       },
 
       // Removes warning for about `additional` section usage
       safeToUseOptionalCaches: true,
 
-      AppCache: false,
+      AppCache: false
     }),
   ],
 
   performance: {
-    assetFilter: (assetFilename) => !(/(\.map$)|(^(main\.|favicon\.))/.test(assetFilename)),
-  },
+    assetFilter: (assetFilename) =>
+      !/(\.map$)|(^(main\.|favicon\.))/.test(assetFilename)
+  }
 });

--- a/src/app.js
+++ b/src/app.js
@@ -83,7 +83,7 @@ if (!window.Intl) {
       Promise.all(
         appLocales.map((locale) =>
           // eslint-disable-next-line global-require
-          import(/* webpackChunkName: "locale-data" */`intl/locale-data/jsonp/${locale}.js`)
+          import(/* webpackChunkName: "intl-locale-data", webpackMode: "weak" */`intl/locale-data/jsonp/${locale}.js`)
         )
       )
     )

--- a/src/containers/App/constants.js
+++ b/src/containers/App/constants.js
@@ -9,7 +9,7 @@
  * export const YOUR_ACTION_CONSTANT = 'yourproject/YourContainer/YOUR_ACTION_CONSTANT';
  */
 
-export const DEFAULT_LOCALE = 'nl';
+export const DEFAULT_LOCALE = process.env.DEFAULT_LOCALE || 'nl';
 
 export const AUTHENTICATE_USER = 'sia/App/AUTHENTICATE_USER';
 export const AUTHORIZE_USER = 'sia/App/AUTHORIZE_USER';

--- a/src/i18n.js
+++ b/src/i18n.js
@@ -9,7 +9,7 @@ import defaultMessages from './translations/en.json';
 import { DEFAULT_LOCALE } from '../src/containers/App/constants';
 
 const translationMessages = {};
-const { LANGUAGES } = process.env;
+const { LANGUAGES = '' } = process.env;
 const appLocales = LANGUAGES.split(',').map((lang) => lang.trim());
 
 appLocales.forEach((lang) => {

--- a/src/i18n.js
+++ b/src/i18n.js
@@ -9,7 +9,8 @@ import defaultMessages from './translations/en.json';
 import { DEFAULT_LOCALE } from '../src/containers/App/constants';
 
 const translationMessages = {};
-const appLocales = process.env.LANGUAGES.split(',').map((lang) => lang.trim());
+const { LANGUAGES } = process.env;
+const appLocales = LANGUAGES.split(',').map((lang) => lang.trim());
 
 appLocales.forEach((lang) => {
   try {

--- a/src/i18n.js
+++ b/src/i18n.js
@@ -15,8 +15,8 @@ const appLocales = LANGUAGES.split(',').map((lang) => lang.trim());
 appLocales.forEach((lang) => {
   try {
     /* eslint-disable global-require */
-    const langData = require(`react-intl/locale-data/${lang}`);
-    const messages = require(`./translations/${lang}.json`);
+    const langData = import(/* webpackChunkName: "react-intl-locale-data", webpackMode: "eager" */`react-intl/locale-data/${lang}`);
+    const messages = require(/* webpackChunkName: "translation", webpackMode: "lazy-once" */`./translations/${lang}.json`);
     /* eslint-enable */
 
     addLocaleData(langData);


### PR DESCRIPTION
This PR fixes an issue where the value of an env var, when not provided, would crash the application. In  addition to that, this PR updates `.env.local` with required variables and sets Webpack require strategy for translation files.